### PR TITLE
Define maximum session duration variable for build roles

### DIFF
--- a/ec2amicreate_roles.tf
+++ b/ec2amicreate_roles.tf
@@ -8,9 +8,10 @@
 resource "aws_iam_role" "ec2amicreate_role_production" {
   provider = aws.images-production-ami
 
-  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
-  description        = local.ec2amicreate_role_description
-  name               = local.ec2amicreate_role_name
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_doc.json
+  description          = local.ec2amicreate_role_description
+  max_session_duration = var.ec2amicreate_role_max_session_duration
+  name                 = local.ec2amicreate_role_name
   tags = merge(var.tags,
     {
       "GitHub_Secret_Name"             = "BUILD_ROLE_TO_ASSUME_PRODUCTION",
@@ -40,9 +41,10 @@ resource "aws_iam_role_policy_attachment" "parameterstorereadonly_policy_attachm
 resource "aws_iam_role" "ec2amicreate_role_staging" {
   provider = aws.images-staging-ami
 
-  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
-  description        = local.ec2amicreate_role_description
-  name               = local.ec2amicreate_role_name
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_doc.json
+  description          = local.ec2amicreate_role_description
+  max_session_duration = var.ec2amicreate_role_max_session_duration
+  name                 = local.ec2amicreate_role_name
   tags = merge(var.tags,
     {
       "GitHub_Secret_Name"             = "BUILD_ROLE_TO_ASSUME_STAGING",

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,7 @@ variable "ssm_parameters" {
 }
 
 variable "user_name" {
+  type        = string
   description = "The name to associate with the AWS IAM user (e.g. test-ami-build-iam-user-tf-module)."
 }
 
@@ -20,16 +21,19 @@ variable "user_name" {
 # ------------------------------------------------------------------------------
 
 variable "ec2amicreate_policy_name" {
+  type        = string
   description = "The name of the IAM policy in the Images account that allows all of the actions needed to create an AMI."
   default     = "EC2AMICreate"
 }
 
 variable "ec2amicreate_role_description" {
+  type        = string
   description = "The description to associate with the IAM role that allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."
   default     = "Allows the %s IAM user to create AMIs."
 }
 
 variable "ec2amicreate_role_name" {
+  type        = string
   description = "The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."
   default     = "EC2AMICreate-%s"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "ec2amicreate_role_description" {
   default     = "Allows the %s IAM user to create AMIs."
 }
 
+variable "ec2amicreate_role_max_session_duration" {
+  type        = number
+  description = "The maximum session duration (in seconds) when assuming the IAM role that allows this IAM user to create AMIs."
+  default     = 3600
+}
+
 variable "ec2amicreate_role_name" {
   type        = string
   description = "The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds a new optional variable that defines the maximum session duration (in seconds) when assuming the IAM role that allows the build user to create AMIs.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We encountered a situation where the default AWS session duration of one hour was not sufficient.  This PR enables us to easily create a build user with an associated AMI build role that can be assumed for more than one hour.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I successfully applied the example Terraform (after temporarily passing in a custom value for `ec2amicreate_role_max_session_duration`) and verified that the session duration appeared correctly in the AWS console.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
