### PR TITLE
Additional policies for build user

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ module "example" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
+| additional_policy_arns_production | The list of additional Production IAM policy ARNs to attach to this IAM user (e.g. ["arn:aws:iam::111111111111:policy/ReadFromMyBucket", "arn:aws:iam::111111111111:policy/ReadFromMyOtherBucket"]). | list(string) | `[]` | no |
+| additional_policy_arns_staging | The list of additional Staging IAM policy ARNs to attach to this IAM user (e.g. ["arn:aws:iam::222222222222:policy/ReadFromMyBucket", "arn:aws:iam::222222222222:policy/ReadFromMyOtherBucket"]). | list(string) | `[]` | no |
 | ec2amicreate_policy_name | The name of the IAM policy in the Images account that allows all of the actions needed to create an AMI. | string | `EC2AMICreate` | no |
 | ec2amicreate_role_description | The description to associate with the IAM role that allows this IAM user to create AMIs.  Note that a "%s" in this value will get replaced with the user_name variable. | string | `Allows the %s IAM user to create AMIs` | no |
 | ec2amicreate_role_max_session_duration | The maximum session duration (in seconds) when assuming the IAM role that allows this IAM user to create AMIs. | number | `3600` | no |

--- a/additional_policy_attachments.tf
+++ b/additional_policy_attachments.tf
@@ -1,0 +1,25 @@
+# ------------------------------------------------------------------------------
+# Attach additional policies to the IAM role that allows creation of AMIs and
+# read-only access to any specified SSM Parameter Store parameters in the
+# Images accounts (Production and Staging).
+# ------------------------------------------------------------------------------
+
+# Attach additional policies to the Production EC2AMICreate role
+resource "aws_iam_role_policy_attachment" "additional_policy_production" {
+  for_each = toset(var.additional_policy_arns_production)
+
+  provider = aws.images-production-ami
+
+  policy_arn = each.value
+  role       = aws_iam_role.ec2amicreate_role_production.name
+}
+
+# Attach additional policies to the Staging EC2AMICreate role
+resource "aws_iam_role_policy_attachment" "additional_policy_staging" {
+  for_each = toset(var.additional_policy_arns_staging)
+
+  provider = aws.images-staging-ami
+
+  policy_arn = each.value
+  role       = aws_iam_role.ec2amicreate_role_staging.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,18 @@ variable "user_name" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
+variable "additional_policy_arns_production" {
+  type        = list(string)
+  description = "The list of additional Production IAM policy ARNs to attach to this IAM user (e.g. [\"arn:aws:iam::123456789012:policy/ReadFromMyBucket\", \"arn:aws:iam::123456789012:policy/ReadFromMyOtherBucket\"])."
+  default     = []
+}
+
+variable "additional_policy_arns_staging" {
+  type        = list(string)
+  description = "The list of additional Staging IAM policy ARNs to attach to this IAM user (e.g. [\"arn:aws:iam::123456789012:policy/ReadFromMyBucket\", \"arn:aws:iam::123456789012:policy/ReadFromMyOtherBucket\"])."
+  default     = []
+}
+
 variable "ec2amicreate_policy_name" {
   type        = string
   description = "The name of the IAM policy in the Images account that allows all of the actions needed to create an AMI."


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds the ability to specify a list of policy ARNs to be added to the build user role (both in Production and Staging).

Resolves #3.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We have a need for the build user to be able to read objects from a bucket.  This PR enables that by allowing us to attach custom bucket-access policies (e.g. those created with the new [`s3-read-role-tf-module`](https://github.com/cisagov/s3-read-role-tf-module)) to our build user.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I created a test user for [`nessus-packer`](https://github.com/cisagov/nessus-packer) and verified that the additional staging bucket-access policy was indeed added to the build user's `EC2AMICreate-test-nessus-packer` role.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
