### PR TITLE
Ensure that the production and staging roles are tagged appropriately

### DIFF
--- a/user.tf
+++ b/user.tf
@@ -11,9 +11,17 @@ module "ci_user" {
     aws.staging    = aws.images-staging-ami
   }
 
+  production_role_tags = {
+    "GitHub_Secret_Name"             = "BUILD_ROLE_TO_ASSUME_PRODUCTION",
+    "GitHub_Secret_Terraform_Lookup" = "arn",
+  }
   role_description          = local.ec2amicreate_role_description
   role_max_session_duration = var.ec2amicreate_role_max_session_duration
   role_name                 = local.ec2amicreate_role_name
-  user_name                 = var.user_name
-  tags                      = var.tags
+  staging_role_tags = {
+    "GitHub_Secret_Name"             = "BUILD_ROLE_TO_ASSUME_STAGING",
+    "GitHub_Secret_Terraform_Lookup" = "arn",
+  }
+  user_name = var.user_name
+  tags      = var.tags
 }


### PR DESCRIPTION
## 🗣 Description

This pull request ensures that the production and staging roles are appropriately tagged for our GitHub Actions CI workflows.

## 💭 Motivation and Context

Without this change, the `terraform-to-secrets` script in [cisagov/development-guide](https://github.com/cisagov/development-guide) will not generate the appropriate secrets.

## 🧪 Testing

I verified using [cisagov/kali-packer](https://github.com/cisagov/kali-packer) that these changes result in appropriately-tagged roles.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
