### PR TITLE
Support build users with no SSM Parameter Store access

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ module "example" {
 | ec2amicreate\_role\_description | The description to associate with the IAM role that allows this IAM user to create AMIs.  Note that a "%s" in this value will get replaced with the user\_name variable. | `string` | `"Allows the %s IAM user to create AMIs."` | no |
 | ec2amicreate\_role\_max\_session\_duration | The maximum session duration (in seconds) when assuming the IAM role that allows this IAM user to create AMIs. | `number` | `3600` | no |
 | ec2amicreate\_role\_name | The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a "%s" in this value will get replaced with the user\_name variable. | `string` | `"EC2AMICreate-%s"` | no |
-| ssm\_parameters | The AWS SSM parameters that the IAM user needs to be able to read (e.g. ["/example/parameter1", "/example/config"]). | `list(string)` | n/a | yes |
+| ssm\_parameters | The AWS SSM parameters that the IAM user needs to be able to read (e.g. ["/example/parameter1", "/example/config"]). | `list(string)` | `[]` | no |
 | user\_name | The name to associate with the AWS IAM user (e.g. test-ami-build-iam-user-tf-module). | `string` | n/a | yes |
 
 ## Outputs ##

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,10 @@ data "aws_caller_identity" "images_staging" {
 }
 
 locals {
+  # Toggle whether or not to create the parameterstorereadonly_role resources
+  # based on whether or not the ssm_parameters variable is populated.
+  create_parameterstorereadonly_role_resources = (length(var.ssm_parameters) > 0) ? 1 : 0
+
   # If var.ec2amicreate_role_description contains "%s", use format()
   # to replace the "%s" with var.user_name, otherwise just use
   # var.ec2amicreate_role_description as is

--- a/parameterstorereadonly_roles.tf
+++ b/parameterstorereadonly_roles.tf
@@ -6,6 +6,7 @@
 
 module "parameterstorereadonly_role_production" {
   source = "github.com/cisagov/ssm-read-role-tf-module"
+  count  = local.create_parameterstorereadonly_role_resources
 
   providers = {
     aws = aws.images-production-ssm
@@ -19,6 +20,7 @@ module "parameterstorereadonly_role_production" {
 
 module "parameterstorereadonly_role_staging" {
   source = "github.com/cisagov/ssm-read-role-tf-module"
+  count  = local.create_parameterstorereadonly_role_resources
 
   providers = {
     aws = aws.images-staging-ssm

--- a/policy_attachments.tf
+++ b/policy_attachments.tf
@@ -10,9 +10,10 @@ resource "aws_iam_role_policy_attachment" "ec2amicreate_policy_attachment_produc
 # Attach the Production ParameterStoreReadOnly policy to the
 # Production EC2AMICreate role
 resource "aws_iam_role_policy_attachment" "parameterstorereadonly_policy_attachment_production" {
+  count    = local.create_parameterstorereadonly_role_resources
   provider = aws.images-production-ami
 
-  policy_arn = module.parameterstorereadonly_role_production.policy.arn
+  policy_arn = module.parameterstorereadonly_role_production[0].policy.arn
   role       = module.ci_user.production_role.name
 }
 
@@ -28,8 +29,9 @@ resource "aws_iam_role_policy_attachment" "ec2amicreate_policy_attachment_stagin
 # Attach the Staging ParameterStoreReadOnly policy to the Staging
 # EC2AMICreate role
 resource "aws_iam_role_policy_attachment" "parameterstorereadonly_policy_attachment_staging" {
+  count    = local.create_parameterstorereadonly_role_resources
   provider = aws.images-staging-ami
 
-  policy_arn = module.parameterstorereadonly_role_staging.policy.arn
+  policy_arn = module.parameterstorereadonly_role_staging[0].policy.arn
   role       = module.ci_user.staging_role.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "ssm_parameters" {
-  type        = list(string)
-  description = "The AWS SSM parameters that the IAM user needs to be able to read (e.g. [\"/example/parameter1\", \"/example/config\"])."
-}
-
 variable "user_name" {
   type        = string
   description = "The name to associate with the AWS IAM user (e.g. test-ami-build-iam-user-tf-module)."
@@ -54,4 +49,10 @@ variable "ec2amicreate_role_name" {
   type        = string
   description = "The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."
   default     = "EC2AMICreate-%s"
+}
+
+variable "ssm_parameters" {
+  type        = list(string)
+  description = "The AWS SSM parameters that the IAM user needs to be able to read (e.g. [\"/example/parameter1\", \"/example/config\"])."
+  default     = []
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates this module to support creating build users who do not need access to any SSM Parameter Store keys.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

There are cases where a build user may not need access to any SSM Parameter Store keys but must provide some kind of key values in order to leverage this module. This is undesirable behavior in my mind so this pull request provides the means to cleanly create such users without dummy values.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
