### PR TITLE
Make build user support a single build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module "example" {
 |------|---------|
 | aws | >= 4.9 |
 | aws.images-ami | >= 4.9 |
+| aws.images-ssm | >= 4.9 |
 
 ## Modules ##
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,8 @@ module "example" {
 
   providers = {
     aws                       = aws
-    aws.images-production-ami = aws.images-production-ami
-    aws.images-staging-ami    = aws.images-staging-ami
-    aws.images-production-ssm = aws.images-production-ssm
-    aws.images-staging-ssm    = aws.images-staging-ssm
+    aws.images-ami = aws.images-ami
+    aws.images-ssm = aws.images-ssm
   }
 
   ssm_parameters = ["/example/parameter1", "/example/config"]
@@ -41,41 +39,40 @@ module "example" {
 | Name | Version |
 |------|---------|
 | aws | >= 4.9 |
-| aws.images-production-ami | >= 4.9 |
-| aws.images-staging-ami | >= 4.9 |
+| aws.images-ami | >= 4.9 |
 
 ## Modules ##
 
 | Name | Source | Version |
 |------|--------|---------|
-| ci\_user | github.com/cisagov/ci-iam-user-tf-module | n/a |
-| parameterstorereadonly\_role\_production | github.com/cisagov/ssm-read-role-tf-module | n/a |
-| parameterstorereadonly\_role\_staging | github.com/cisagov/ssm-read-role-tf-module | n/a |
+| parameterstorereadonly\_role | github.com/cisagov/ssm-read-role-tf-module | n/a |
 
 ## Resources ##
 
 | Name | Type |
 |------|------|
-| [aws_iam_role_policy_attachment.additional_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.additional_policy_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.ec2amicreate_policy_attachment_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.ec2amicreate_policy_attachment_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.parameterstorereadonly_policy_attachment_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.parameterstorereadonly_policy_attachment_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_caller_identity.images_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.images_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_access_key.build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
+| [aws_iam_role.ec2amicreate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.additional_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ec2amicreate_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.parameterstorereadonly_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_user.build](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy.assume_ec2amicreate_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
+| [aws_caller_identity.images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_ec2amicreate_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_policy\_arns\_production | The list of additional Production IAM policy ARNs to attach to this IAM user (e.g. ["arn:aws:iam::123456789012:policy/ReadFromMyBucket", "arn:aws:iam::123456789012:policy/ReadFromMyOtherBucket"]). | `list(string)` | `[]` | no |
-| additional\_policy\_arns\_staging | The list of additional Staging IAM policy ARNs to attach to this IAM user (e.g. ["arn:aws:iam::123456789012:policy/ReadFromMyBucket", "arn:aws:iam::123456789012:policy/ReadFromMyOtherBucket"]). | `list(string)` | `[]` | no |
+| additional\_policy\_arns | The list of additional IAM policy ARNs to attach to this IAM user (e.g. ["arn:aws:iam::123456789012:policy/ReadFromMyBucket", "arn:aws:iam::123456789012:policy/ReadFromMyOtherBucket"]). | `list(string)` | `[]` | no |
 | ec2amicreate\_policy\_name | The name of the IAM policy in the Images account that allows all of the actions needed to create an AMI. | `string` | `"EC2AMICreate"` | no |
 | ec2amicreate\_role\_description | The description to associate with the IAM role that allows this IAM user to create AMIs.  Note that a "%s" in this value will get replaced with the user\_name variable. | `string` | `"Allows the %s IAM user to create AMIs."` | no |
 | ec2amicreate\_role\_max\_session\_duration | The maximum session duration (in seconds) when assuming the IAM role that allows this IAM user to create AMIs. | `number` | `3600` | no |
-| ec2amicreate\_role\_name | The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a "%s" in this value will get replaced with the user\_name variable. | `string` | `"EC2AMICreate-%s"` | no |
+| ec2amicreate\_role\_name | The name to assign the IAM role that allows this IAM user to create AMIs.  Note that a "%s" in this value will get replaced with the user\_name variable. | `string` | `"EC2AMICreate-%s"` | no |
+| ec2amicreate\_role\_tags | Extra tags to apply to the IAM role that allows this IAM user to create AMIs. | `map(string)` | ```{ "GitHub_Secret_Name": "BUILD_ROLE_TO_ASSUME", "GitHub_Secret_Terraform_Lookup": "arn" }``` | no |
 | ssm\_parameters | The AWS SSM parameters that the IAM user needs to be able to read (e.g. ["/example/parameter1", "/example/config"]). | `list(string)` | `[]` | no |
 | user\_name | The name to associate with the AWS IAM user (e.g. test-ami-build-iam-user-tf-module). | `string` | n/a | yes |
 
@@ -84,8 +81,7 @@ module "example" {
 | Name | Description |
 |------|-------------|
 | access\_key | The IAM access key associated with the IAM user created by this module. |
-| ec2amicreate\_role\_production | The IAM role that the CI user can assume in the production account to create AMIs. |
-| ec2amicreate\_role\_staging | The IAM role that the CI user can assume in the staging account to create AMIs. |
+| ec2amicreate\_role | The IAM role that the CI user can assume to create AMIs. |
 | user | The IAM user created by this module. |
 <!-- END_TF_DOCS -->
 

--- a/additional_policy_attachments.tf
+++ b/additional_policy_attachments.tf
@@ -1,25 +1,15 @@
 # ------------------------------------------------------------------------------
 # Attach additional policies to the IAM role that allows creation of
 # AMIs and read-only access to any specified SSM Parameter Store
-# parameters in the Images accounts (Production and Staging).
+# parameters in the Images account.
 # ------------------------------------------------------------------------------
 
-# Attach additional policies to the Production EC2AMICreate role
-resource "aws_iam_role_policy_attachment" "additional_policy_production" {
-  for_each = toset(var.additional_policy_arns_production)
+# Attach additional policies to the EC2AMICreate role
+resource "aws_iam_role_policy_attachment" "additional_policy" {
+  for_each = toset(var.additional_policy_arns)
 
-  provider = aws.images-production-ami
-
-  policy_arn = each.value
-  role       = module.ci_user.production_role.name
-}
-
-# Attach additional policies to the Staging EC2AMICreate role
-resource "aws_iam_role_policy_attachment" "additional_policy_staging" {
-  for_each = toset(var.additional_policy_arns_staging)
-
-  provider = aws.images-staging-ami
+  provider = aws.images-ami
 
   policy_arn = each.value
-  role       = module.ci_user.staging_role.name
+  role       = aws_iam_role.ec2amicreate.name
 }

--- a/assume_role.tf
+++ b/assume_role.tf
@@ -1,0 +1,22 @@
+# IAM policy document that allows assumption of the AMI creation role
+data "aws_iam_policy_document" "assume_ec2amicreate_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      aws_iam_role.ec2amicreate.arn,
+    ]
+  }
+}
+
+# The IAM policy that allows assumption of the AMI creation role
+resource "aws_iam_user_policy" "assume_ec2amicreate_role" {
+  name   = "Assume${aws_iam_role.ec2amicreate.name}"
+  policy = data.aws_iam_policy_document.assume_ec2amicreate_role_doc.json
+  user   = aws_iam_user.build.name
+}

--- a/assume_role_policy_doc.tf
+++ b/assume_role_policy_doc.tf
@@ -1,0 +1,24 @@
+# ------------------------------------------------------------------------------
+# Create an IAM policy document that allows any user to assume the role with
+# which this policy is associated.  The user must still be given permission to
+# assume this role in the Users account.
+#
+# We do not restrict the users who can assume this role to only the AMI builder
+# IAM user to allow admin users to assume this role for debugging and testing.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assume_role_doc" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    principals {
+      identifiers = [
+        data.aws_caller_identity.users.account_id,
+      ]
+      type = "AWS"
+    }
+  }
+}

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -39,7 +39,6 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | access\_key | The IAM access key for the test-ami-build-iam-user-tf-module user. |
-| ec2amicreate\_role\_production | The IAM role that allows creation of AMIs in Production by the test-ami-build-iam-user-tf-module user. |
-| ec2amicreate\_role\_staging | The IAM role that allows creation of AMIs in Staging by the test-ami-build-iam-user-tf-module user. |
+| ec2amicreate\_role | The IAM role that allows creation of AMIs by the test-ami-build-iam-user-tf-module user. |
 | user | The test-ami-build-iam-user-tf-module IAM user. |
 <!-- END_TF_DOCS -->

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -14,45 +14,23 @@ provider "aws" {
   region  = "us-east-1"
 }
 
-# ProvisionEC2AMICreateRoles AWS provider for the Images (Production) account
+# ProvisionEC2AMICreateRoles AWS provider for the Images account
 provider "aws" {
-  alias = "images-production-ami"
+  alias = "images-ami"
   default_tags {
     tags = local.tags
   }
-  profile = "cool-images-production-provisionec2amicreateroles"
+  profile = "cool-images-provisionec2amicreateroles"
   region  = "us-east-1"
 }
 
-# ProvisionEC2AMICreateRoles AWS provider for the Images (Staging) account
+# ProvisionParameterStoreReadRoles AWS provider for the Images account
 provider "aws" {
-  alias = "images-staging-ami"
+  alias = "images-ssm"
   default_tags {
     tags = local.tags
   }
-  profile = "cool-images-staging-provisionec2amicreateroles"
-  region  = "us-east-1"
-}
-
-# ProvisionParameterStoreReadRoles AWS provider for the
-# Images (Production) account
-provider "aws" {
-  alias = "images-production-ssm"
-  default_tags {
-    tags = local.tags
-  }
-  profile = "cool-images-production-provisionparameterstorereadroles"
-  region  = "us-east-1"
-}
-
-# ProvisionParameterStoreReadRoles AWS provider for the
-# Images (Staging) account
-provider "aws" {
-  alias = "images-staging-ssm"
-  default_tags {
-    tags = local.tags
-  }
-  profile = "cool-images-staging-provisionparameterstorereadroles"
+  profile = "cool-images-provisionparameterstorereadroles"
   region  = "us-east-1"
 }
 
@@ -60,11 +38,9 @@ module "iam_user_with_ssm_read" {
   source = "../.."
 
   providers = {
-    aws                       = aws
-    aws.images-production-ami = aws.images-production-ami
-    aws.images-staging-ami    = aws.images-staging-ami
-    aws.images-production-ssm = aws.images-production-ssm
-    aws.images-staging-ssm    = aws.images-staging-ssm
+    aws            = aws
+    aws.images-ami = aws.images-ami
+    aws.images-ssm = aws.images-ssm
   }
 
   ssm_parameters = ["/example/parameter1", "/example/config"]

--- a/examples/basic_usage/outputs.tf
+++ b/examples/basic_usage/outputs.tf
@@ -4,14 +4,9 @@ output "access_key" {
   value       = module.iam_user_with_ssm_read.access_key
 }
 
-output "ec2amicreate_role_production" {
-  description = "The IAM role that allows creation of AMIs in Production by the test-ami-build-iam-user-tf-module user."
-  value       = module.iam_user_with_ssm_read.ec2amicreate_role_production
-}
-
-output "ec2amicreate_role_staging" {
-  description = "The IAM role that allows creation of AMIs in Staging by the test-ami-build-iam-user-tf-module user."
-  value       = module.iam_user_with_ssm_read.ec2amicreate_role_staging
+output "ec2amicreate_role" {
+  description = "The IAM role that allows creation of AMIs by the test-ami-build-iam-user-tf-module user."
+  value       = module.iam_user_with_ssm_read.ec2amicreate_role
 }
 
 output "user" {

--- a/locals.tf
+++ b/locals.tf
@@ -3,12 +3,8 @@
 data "aws_caller_identity" "users" {
 }
 
-data "aws_caller_identity" "images_production" {
-  provider = aws.images-production-ami
-}
-
-data "aws_caller_identity" "images_staging" {
-  provider = aws.images-staging-ami
+data "aws_caller_identity" "images" {
+  provider = aws.images-ami
 }
 
 locals {
@@ -27,9 +23,7 @@ locals {
   ec2amicreate_role_name = length(regexall(".*%s.*", var.ec2amicreate_role_name)) > 0 ? format(var.ec2amicreate_role_name, var.user_name) : var.ec2amicreate_role_name
 
   # Grab all of the necessary account IDs
-  images_production_account_id = data.aws_caller_identity.images_production.account_id
-
-  images_staging_account_id = data.aws_caller_identity.images_staging.account_id
+  images_account_id = data.aws_caller_identity.images.account_id
 
   users_account_id = data.aws_caller_identity.users.account_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,15 @@
 output "access_key" {
   description = "The IAM access key associated with the IAM user created by this module."
   sensitive   = true
-  value       = module.ci_user.access_key
+  value       = aws_iam_access_key.build
 }
 
-output "ec2amicreate_role_production" {
-  description = "The IAM role that the CI user can assume in the production account to create AMIs."
-  value       = module.ci_user.production_role
-}
-
-output "ec2amicreate_role_staging" {
-  description = "The IAM role that the CI user can assume in the staging account to create AMIs."
-  value       = module.ci_user.staging_role
+output "ec2amicreate_role" {
+  description = "The IAM role that the CI user can assume to create AMIs."
+  value       = aws_iam_role.ec2amicreate
 }
 
 output "user" {
   description = "The IAM user created by this module."
-  value       = module.ci_user.user
+  value       = aws_iam_user.build
 }

--- a/parameterstorereadonly_roles.tf
+++ b/parameterstorereadonly_roles.tf
@@ -1,33 +1,18 @@
 # ------------------------------------------------------------------------------
-# Create the IAM roles and policies that allow read-only access
-# to the specified SSM Parameter Store parameters in the
-# Images accounts (Production and Staging).
+# Create the IAM role and policy that allow read-only access to the specified
+# SSM Parameter Store parameters in the Images account.
 # ------------------------------------------------------------------------------
 
-module "parameterstorereadonly_role_production" {
+module "parameterstorereadonly_role" {
   source = "github.com/cisagov/ssm-read-role-tf-module"
   count  = local.create_parameterstorereadonly_role_resources
 
   providers = {
-    aws = aws.images-production-ssm
+    aws = aws.images-ssm
   }
 
   account_ids   = [local.users_account_id]
-  entity_name   = module.ci_user.user.name
-  iam_usernames = [module.ci_user.user.name]
-  ssm_names     = var.ssm_parameters
-}
-
-module "parameterstorereadonly_role_staging" {
-  source = "github.com/cisagov/ssm-read-role-tf-module"
-  count  = local.create_parameterstorereadonly_role_resources
-
-  providers = {
-    aws = aws.images-staging-ssm
-  }
-
-  account_ids   = [local.users_account_id]
-  entity_name   = module.ci_user.user.name
-  iam_usernames = [module.ci_user.user.name]
+  entity_name   = aws_iam_user.build.name
+  iam_usernames = [aws_iam_user.build.name]
   ssm_names     = var.ssm_parameters
 }

--- a/policy_attachments.tf
+++ b/policy_attachments.tf
@@ -1,37 +1,16 @@
-# Attach the Production EC2AMICreate policy to the Production
-# EC2AMICreate role
-resource "aws_iam_role_policy_attachment" "ec2amicreate_policy_attachment_production" {
-  provider = aws.images-production-ami
+# Attach the EC2AMICreate policy to the EC2AMICreate role
+resource "aws_iam_role_policy_attachment" "ec2amicreate_policy_attachment" {
+  provider = aws.images-ami
 
-  policy_arn = "arn:aws:iam::${local.images_production_account_id}:policy/${var.ec2amicreate_policy_name}"
-  role       = module.ci_user.production_role.name
+  policy_arn = "arn:aws:iam::${local.images_account_id}:policy/${var.ec2amicreate_policy_name}"
+  role       = aws_iam_role.ec2amicreate.name
 }
 
-# Attach the Production ParameterStoreReadOnly policy to the
-# Production EC2AMICreate role
-resource "aws_iam_role_policy_attachment" "parameterstorereadonly_policy_attachment_production" {
+# Attach the ParameterStoreReadOnly policy to the EC2AMICreate role
+resource "aws_iam_role_policy_attachment" "parameterstorereadonly_policy_attachment" {
   count    = local.create_parameterstorereadonly_role_resources
-  provider = aws.images-production-ami
+  provider = aws.images-ami
 
-  policy_arn = module.parameterstorereadonly_role_production[0].policy.arn
-  role       = module.ci_user.production_role.name
-}
-
-# Attach the Staging EC2AMICreate policy to the Staging EC2AMICreate
-# role
-resource "aws_iam_role_policy_attachment" "ec2amicreate_policy_attachment_staging" {
-  provider = aws.images-staging-ami
-
-  policy_arn = "arn:aws:iam::${local.images_staging_account_id}:policy/${var.ec2amicreate_policy_name}"
-  role       = module.ci_user.staging_role.name
-}
-
-# Attach the Staging ParameterStoreReadOnly policy to the Staging
-# EC2AMICreate role
-resource "aws_iam_role_policy_attachment" "parameterstorereadonly_policy_attachment_staging" {
-  count    = local.create_parameterstorereadonly_role_resources
-  provider = aws.images-staging-ami
-
-  policy_arn = module.parameterstorereadonly_role_staging[0].policy.arn
-  role       = module.ci_user.staging_role.name
+  policy_arn = module.parameterstorereadonly_role[0].policy.arn
+  role       = aws_iam_role.ec2amicreate.name
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,25 +1,11 @@
 # This is the provider that is used to create the policy that can
-# create AMIs inside the Images Production account.
+# create AMIs inside the Images account.
 provider "aws" {
-  alias = "images-production-ami"
-}
-
-# This is the provider that is used to create the policy that can
-# create AMIs inside the Images Staging account.
-provider "aws" {
-  alias = "images-staging-ami"
+  alias = "images-ami"
 }
 
 # This is the provider that is used to create the role and policy that
-# can read Parameter Store parameters inside the Images Production
-# account.
+# can read Parameter Store parameters inside the Images account.
 provider "aws" {
-  alias = "images-production-ssm"
-}
-
-# This is the provider that is used to create the role and policy that
-# can read Parameter Store parameters inside the Images Staging
-# account.
-provider "aws" {
-  alias = "images-staging-ssm"
+  alias = "images-ssm"
 }

--- a/roles.tf
+++ b/roles.tf
@@ -1,0 +1,10 @@
+# The AMI creation role
+resource "aws_iam_role" "ec2amicreate" {
+  provider = aws.images-ami
+
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_doc.json
+  description          = local.ec2amicreate_role_description
+  max_session_duration = var.ec2amicreate_role_max_session_duration
+  name                 = local.ec2amicreate_role_name
+  tags                 = var.ec2amicreate_role_tags
+}

--- a/user.tf
+++ b/user.tf
@@ -2,25 +2,16 @@
 # Create an IAM user and an associated access key
 # ------------------------------------------------------------------------------
 
-module "ci_user" {
-  source = "github.com/cisagov/ci-iam-user-tf-module"
+# The IAM user being created
+resource "aws_iam_user" "build" {
+  provider = aws
 
-  providers = {
-    aws            = aws
-    aws.production = aws.images-production-ami
-    aws.staging    = aws.images-staging-ami
-  }
+  name = var.user_name
+}
 
-  production_role_tags = {
-    "GitHub_Secret_Name"             = "BUILD_ROLE_TO_ASSUME_PRODUCTION",
-    "GitHub_Secret_Terraform_Lookup" = "arn",
-  }
-  role_description          = local.ec2amicreate_role_description
-  role_max_session_duration = var.ec2amicreate_role_max_session_duration
-  role_name                 = local.ec2amicreate_role_name
-  staging_role_tags = {
-    "GitHub_Secret_Name"             = "BUILD_ROLE_TO_ASSUME_STAGING",
-    "GitHub_Secret_Terraform_Lookup" = "arn",
-  }
-  user_name = var.user_name
+# The IAM access key for the user
+resource "aws_iam_access_key" "build" {
+  provider = aws
+
+  user = aws_iam_user.build.name
 }

--- a/user.tf
+++ b/user.tf
@@ -3,6 +3,9 @@
 # ------------------------------------------------------------------------------
 
 # The IAM user being created
+# TODO: Revert to using cisagov/ci-iam-user-tf-module after it has been updated
+# to create single-environment IAM users.  For details, see:
+# https://github.com/cisagov/ami-build-iam-user-tf-module/issues/63
 resource "aws_iam_user" "build" {
   provider = aws
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,16 +16,9 @@ variable "user_name" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
-variable "additional_policy_arns_production" {
+variable "additional_policy_arns" {
   default     = []
-  description = "The list of additional Production IAM policy ARNs to attach to this IAM user (e.g. [\"arn:aws:iam::123456789012:policy/ReadFromMyBucket\", \"arn:aws:iam::123456789012:policy/ReadFromMyOtherBucket\"])."
-  nullable    = false
-  type        = list(string)
-}
-
-variable "additional_policy_arns_staging" {
-  default     = []
-  description = "The list of additional Staging IAM policy ARNs to attach to this IAM user (e.g. [\"arn:aws:iam::123456789012:policy/ReadFromMyBucket\", \"arn:aws:iam::123456789012:policy/ReadFromMyOtherBucket\"])."
+  description = "The list of additional IAM policy ARNs to attach to this IAM user (e.g. [\"arn:aws:iam::123456789012:policy/ReadFromMyBucket\", \"arn:aws:iam::123456789012:policy/ReadFromMyOtherBucket\"])."
   nullable    = false
   type        = list(string)
 }
@@ -56,6 +49,16 @@ variable "ec2amicreate_role_name" {
   description = "The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."
   nullable    = false
   type        = string
+}
+
+variable "ec2amicreate_role_tags" {
+  default = {
+    "GitHub_Secret_Name"             = "BUILD_ROLE_TO_ASSUME",
+    "GitHub_Secret_Terraform_Lookup" = "arn",
+  }
+  description = "Extra tags to apply to the IAM role that allows this IAM user to create AMIs."
+  nullable    = false
+  type        = map(string)
 }
 
 variable "ssm_parameters" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "ec2amicreate_role_max_session_duration" {
 
 variable "ec2amicreate_role_name" {
   default     = "EC2AMICreate-%s"
-  description = "The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."
+  description = "The name to assign the IAM role that allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."
   nullable    = false
   type        = string
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the build user that is created by this module such that the user can only build AMIs in a single environment.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In the past, we had a single build user that was capable of building AMIs in both a staging and production environment.  In our target (near-future) state, each packer repo will have one build user per environment (e.g. dev, staging, production, etc.)

This supports our overall goal of a COOL system where each environment's IAM users exist in an AWS account specific to that environment and no others.

> [!NOTE] 
> I am marking this PR as "blocked" until the related skeleton-packer PR (https://github.com/cisagov/skeleton-packer/pull/393) has been reviewed and approved, to minimize the amount of time that our cisagov packer repos are out of sync with the latest changes in this module. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I used the version of the module in this PR to successfully create dev, staging, and production build users for https://github.com/cisagov/skeleton-packer/pull/393.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Update all cisagov *-packer repos to reflect the changes in this PR (see https://github.com/cisagov/skeleton-packer/pull/393)
- [x] Create/update dev/staging/prod build users for all cisagov *-packer repos